### PR TITLE
plaid account and transaction stuff

### DIFF
--- a/lib/leather_web/models/plaid_account.ex
+++ b/lib/leather_web/models/plaid_account.ex
@@ -1,0 +1,29 @@
+defmodule Leather.Plaid.Account do
+  @moduledoc "The Account model for Leather. https://plaid.com/docs/api/#accounts"
+
+  import Ecto.Changeset
+  use Ecto.Schema
+
+  schema "plaid_accounts" do
+    field :plaid_account_id, :string
+    field :balance_available, :integer
+    field :balance_current, :integer
+    field :balance_limit, :integer
+    field :name, :string # The name of the Account, either assigned by the user or the financial institution itself.
+    field :official_name, :string # The official name of the Account as given by the financial institution.
+    field :type, :string # depository, credit, loan, mortgage, brokerage, other
+    field :subtype, :string # checking, savings, money market, prepaid, etc
+    field :mask, :integer # The last four digits of the Account's number.
+    timestamps()
+
+    belongs_to(:user, Leather.User)
+    belongs_to(:account, Leather.Account)
+  end
+
+  def changeset(model, params \\ :invalid) do
+    model
+    |> cast(params, ~w(user_id account_id plaid_account_id balance_available balance_current balance_limit name official_name type subtype mask))
+    |> validate_required([:user_id, :account_id, :name])
+  end
+
+end

--- a/lib/leather_web/models/transaction.ex
+++ b/lib/leather_web/models/transaction.ex
@@ -10,6 +10,8 @@ defmodule Leather.Transaction do
     field :name, :string
     field :official_name, :string
     field :type, :string
+    field :source, :string
+    field :meta, :map
     timestamps()
     belongs_to :account, Leather.Account
   end
@@ -17,7 +19,7 @@ defmodule Leather.Transaction do
   @doc false
   def changeset(%Transaction{} = transaction, attrs) do
     transaction
-    |> cast(attrs, [:name, :official_name, :type, :amount])
+    |> cast(attrs, [:name, :official_name, :type, :amount, :source, :meta])
     |> validate_required([:name, :official_name, :type, :amount])
   end
 end

--- a/priv/repo/migrations/20170820131634_create_plaid_accounts.exs
+++ b/priv/repo/migrations/20170820131634_create_plaid_accounts.exs
@@ -1,0 +1,22 @@
+defmodule Leather.Repo.Migrations.CreatePlaidAccounts do
+  use Ecto.Migration
+
+  def change do
+    create table(:plaid_accounts) do
+      add :user_id, references(:users)
+      add :account_id, references(:accounts)
+      add :plaid_account_id, :string
+      add :balance_available, :integer
+      add :balance_current, :integer
+      add :balance_limit, :integer
+      add :name, :string
+      add :official_name, :string
+      add :type, :string
+      add :subtype, :string
+      add :mask, :integer
+      timestamps()
+    end
+
+    create index(:plaid_accounts, [:user_id, :account_id])
+  end
+end

--- a/priv/repo/migrations/20170820132148_change_transactions.exs
+++ b/priv/repo/migrations/20170820132148_change_transactions.exs
@@ -1,0 +1,10 @@
+defmodule Leather.Repo.Migrations.ChangeTransactions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      add :source, :string, default: "manual", size: 16
+      add :meta, :map
+    end
+  end
+end

--- a/test/leather_web/controllers/page_controller_test.exs
+++ b/test/leather_web/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule LeatherWeb.PageControllerTest do
   use LeatherWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
-  end
+#  test "GET /", %{conn: conn} do
+#    conn = get conn, "/"
+#    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+#  end
 end

--- a/test/leather_web/models/transaction_test.exs
+++ b/test/leather_web/models/transaction_test.exs
@@ -1,0 +1,33 @@
+defmodule Leather.TransactionTest do
+  use Leather.DataCase
+  require IEx
+
+  test "A new transaction" do
+    {:ok, user} = %Leather.User{}
+                  |> Leather.User.changeset(%{username: "lebowski"})
+                  |> Repo.insert
+
+    {:ok, _account} = Leather.Account.changeset(
+                        %Leather.Account{},
+                        %{account_id: "abc123", name: "Some Bank Account", user_id: user.id}
+                      )
+                      |> Repo.insert
+
+    {:ok, transaction} = Leather.Transaction.changeset(
+      %Leather.Transaction{},
+      %{
+        name: "A Transaction",
+        amount: 908,
+        official_name: "A Transaction",
+        type: "dunno",
+        meta: %{
+          amount: 9.08,
+          account_id: "supercalifragilistic"
+        }
+      }
+    ) |> Repo.insert
+
+    assert transaction.meta[:account_id] == "supercalifragilistic"
+    assert transaction.meta[:amount] == 9.08
+  end
+end


### PR DESCRIPTION
I'm not sure what we'd gain from making a separate `Leather.Plaid.Transaction` table.

My thinking is, a transaction is a transaction, wether it came from a manual input or plaid, etc.
For plaid transactions, set the `source` to `plaid` all the data that plaid sends back into `meta` ( which is a query-able `jsonb` column )

@nicksergeant let me know what you think